### PR TITLE
Multiple color-swatch sections

### DIFF
--- a/components/molecules/section.twig
+++ b/components/molecules/section.twig
@@ -8,7 +8,7 @@
       </div>
     {% endif %}
 
-    {% if section.reference|split(".")|last == "colors" %}
+    {% if "color-swatches" in section.reference|split(".")|last %}
 
       {% include "color_grid.twig" with section only %}
 

--- a/index.twig
+++ b/index.twig
@@ -41,7 +41,7 @@
       {% for section in sections %}
         {% if section.depth == 1 %}
           {% include "components/molecules/page_header.twig" %}
-          {% if section.reference == "colors" %}
+          {% if "color-swatches" in section.reference %}
             {% include "components/molecules/color_grid.twig" with section only %}
           {% endif %}
 


### PR DESCRIPTION
Improves color swatch handling.

Now once can create multiple groupings.
```
Styleguide brand-color-swatches
```
```
Styleguide secondary-color-swatches
```

```
Styleguide brand.color-swatches
```
Styleguide brand.secondary-color-swatches
```

Would all generate different color groupings.
Basically anything ending in ```color-swatches' gets used.```